### PR TITLE
Add status reports for task lists

### DIFF
--- a/FUNCTIONS-DOC-STATUS.md
+++ b/FUNCTIONS-DOC-STATUS.md
@@ -1,0 +1,11 @@
+# Functions Documentation Status
+
+The `functions/README.md` describes several Cloud Functions used in Propagentic. The repository includes TypeScript implementations for these functions.
+
+## Implemented
+- `classifyMaintenanceRequest` triggers on ticket creation and updates the ticket with a category and urgency.
+- `matchContractorToTicket` is fully implemented in `functions/src/matchContractorToTicket.ts` with logic to prioritize preferred contractors.
+- `notifyAssignedContractor`, `sendTenantInvitation`, `acceptPropertyInvite`, and related invitation functions exist in the `functions/src` directory and are exported in `index.ts`.
+
+## Differences
+- The plain JavaScript versions in `functions/functions/` are placeholders that log and return dummy data. Deployment uses the compiled files under `functions/lib/` but these stubs remain in the repository.

--- a/INVITE-TASKS-STATUS.md
+++ b/INVITE-TASKS-STATUS.md
@@ -1,0 +1,13 @@
+# Invitation Workflow Task Status
+
+`InviteTASKS.md` outlines the steps for the tenant invitation flow. Most development items are implemented.
+
+## Completed
+- Firestore imports and improved error handling added to `createTenantInvite` on the landlord pages.
+- `InviteTenantModal` accepts a list of properties and allows property selection before sending an invite.
+- Tenant side components display invites via `InvitationBanner` and call `inviteService.updateInviteStatus` when accepting or declining.
+- Callable functions `acceptPropertyInvite` and `rejectPropertyInvite` are implemented and exported.
+- `createNotificationOnInvite` in `inviteTriggers.ts` stores related data (`inviteId`, `propertyId`, `propertyName`, `landlordName`).
+
+## Missing
+- End-to-end testing scenarios in Task 6 have not been documented or automated.

--- a/LANDLORD-MVP-STATUS.md
+++ b/LANDLORD-MVP-STATUS.md
@@ -1,0 +1,13 @@
+# Landlord Dashboard Task Status
+
+The original checklist in `LANDLORD-MVP-TASKS.md` tracks progress toward a functional landlord dashboard. Implementation in the repository shows all features completed except the final review/testing step.
+
+## Completed
+- Dashboard routing is verified and property loading errors were fixed.
+- Empty state UI is present.
+- Property management features (`AddPropertyModal`, `PropertyCard`, and property list display) are working.
+- Tenant invitation UI and Firestore record creation via `createTenantInvite` are implemented.
+- Mock data has been removed.
+
+## Outstanding
+- **Code Review & End-to-End Testing** remains unchecked in the task file and no dedicated tests are present.

--- a/README-FEATURE-STATUS.md
+++ b/README-FEATURE-STATUS.md
@@ -1,0 +1,12 @@
+# Project Feature Summary
+
+The root `README.md` lists several key capabilities. The codebase provides implementations for most of these features.
+
+- **Role-based authentication** is implemented through `AuthContext` and Firebase Authentication.
+- **Maintenance request submission with photo uploads** is available via `MaintenanceSurvey.tsx` and related services.
+- **AI classification** is handled by the `classifyMaintenanceRequest` Cloud Function and frontend hook `useMaintenanceAI`.
+- **Contractor matching** logic exists in TypeScript but the JavaScript stubs remain, so automatic contractor assignment may not be fully wired up.
+- **Landlord dashboard** components (`PropertiesPage`, `TenantsPage`) and invite flow are operational.
+- **Notification functions** such as `notifyAssignedContractor` are present with support for Twilio via `notificationDelivery.js`.
+
+Overall the feature list in the README aligns with the code, though some areas like contractor matching and end‑to‑end testing are still unfinished.

--- a/TENANT-DASHBOARD-STATUS.md
+++ b/TENANT-DASHBOARD-STATUS.md
@@ -1,0 +1,15 @@
+# Tenant Dashboard Task Status
+
+`TENANT-DASHBOARD-TASKS.md` lists all items as incomplete, but the codebase implements many of the phase 1 features.
+
+## Completed
+- `TenantDashboard.tsx` exists and fetches pending invitations and property details using `useAuth` and `inviteService`.
+- Invitations are displayed using `InvitationBanner` with accept/decline handlers.
+- Backend functions `acceptPropertyInvite` and `rejectPropertyInvite` are implemented in `functions/src/userRelationships.ts`.
+- Property information is shown via `PropertyList` and tenants can navigate to the maintenance request form.
+- `MaintenanceRequestModal.jsx` component is present and a survey form at `/maintenance/new` creates tickets via `dataService`.
+
+## Missing or Partial
+- The dashboard does not show past maintenance requests and does not use `MaintenanceRequestModal` directly.
+- Fetching of existing tickets and display of a request list is not implemented.
+- Phase 3 refinement/testing tasks remain open.


### PR DESCRIPTION
## Summary
- document progress for landlord dashboard tasks
- detail tenant dashboard progress and gaps
- outline invite workflow status
- note function implementations vs docs
- summarize actual features in README

## Testing
- `npm test` *(fails: vitest not found)*