### PR TITLE
Implement AI follow‑up chat

### DIFF
--- a/src/components/tenant/AIMaintenanceChat.tsx
+++ b/src/components/tenant/AIMaintenanceChat.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useModelContext } from '../../contexts/ModelContext';
+import useMaintenanceAI from '../../hooks/useMaintenanceAI';
+
+const AIMaintenanceChat: React.FC = () => {
+  const { messages, isLoading } = useModelContext();
+  const { sendMessage, getFollowUpQuestions } = useMaintenanceAI();
+  const [input, setInput] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSend = async () => {
+    if (!input.trim()) return;
+    try {
+      await sendMessage(input.trim());
+      setInput('');
+    } catch (err) {
+      console.error('Failed to send message', err);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const suggestions = getFollowUpQuestions();
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4 max-w-lg mx-auto">
+      <div className="h-64 overflow-y-auto mb-4 space-y-2">
+        {messages.map((msg, idx) => (
+          <div
+            key={idx}
+            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+          >
+            <div
+              className={`px-3 py-2 rounded-lg max-w-[70%] ${
+                msg.role === 'user' ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-800'
+              }`}
+            >
+              {msg.content}
+            </div>
+          </div>
+        ))}
+        {isLoading && <div className="text-sm text-gray-500">AI is typing...</div>}
+        <div ref={messagesEndRef} />
+      </div>
+      <div className="flex">
+        <input
+          type="text"
+          className="flex-1 border border-gray-300 rounded-l px-3 py-2 focus:outline-none"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Describe the issue..."
+        />
+        <button
+          onClick={handleSend}
+          className="px-4 py-2 bg-blue-500 text-white rounded-r"
+          disabled={!input.trim() || isLoading}
+        >
+          Send
+        </button>
+      </div>
+      {suggestions.length > 0 && (
+        <div className="mt-4">
+          <p className="text-sm font-medium text-gray-600 mb-1">Suggested follow-up questions:</p>
+          <ul className="list-disc list-inside text-sm text-gray-700 space-y-1">
+            {suggestions.map((q, i) => (
+              <li key={i}>{q}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AIMaintenanceChat;

--- a/src/hooks/useMaintenanceAI.ts
+++ b/src/hooks/useMaintenanceAI.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useModelContext } from '../contexts/ModelContext';
+import { generateFollowUpQuestions } from '../services/ai/questionEngine';
 
 // Maintenance request classification types
 export type MaintenanceCategory = 
@@ -33,16 +34,33 @@ Provide your classification in JSON format without explanation.
  * Hook for using AI to classify maintenance requests
  */
 export const useMaintenanceAI = () => {
-  const { 
-    addMessage, 
-    setSystemMessage, 
-    getCompletion, 
-    clearContext, 
-    isLoading, 
-    error 
+  const {
+    addMessage,
+    setSystemMessage,
+    getCompletion,
+    clearContext,
+    isLoading,
+    error,
+    messages
   } = useModelContext();
   
   const [classification, setClassification] = useState<MaintenanceClassification | null>(null);
+
+  /** Send a message in the current conversation and get the AI response */
+  const sendMessage = async (message: string): Promise<string> => {
+    addMessage('user', message);
+    const response = await getCompletion();
+    return response.content;
+  };
+
+  /** Get follow-up question suggestions based on conversation context */
+  const getFollowUpQuestions = () => generateFollowUpQuestions(messages);
+
+  /** Reset the conversation context */
+  const resetConversation = () => {
+    clearContext();
+    setClassification(null);
+  };
 
   /**
    * Classifies a maintenance request using the AI
@@ -72,6 +90,10 @@ export const useMaintenanceAI = () => {
 
   return {
     classifyMaintenanceRequest,
+    sendMessage,
+    getFollowUpQuestions,
+    resetConversation,
+    messages,
     classification,
     isLoading,
     error,

--- a/src/services/ai/questionEngine.ts
+++ b/src/services/ai/questionEngine.ts
@@ -1,0 +1,58 @@
+export type FollowUpQuestion = string;
+
+import { ModelMessage } from '../modelContext';
+
+function detectIssueType(messages: ModelMessage[]): string | null {
+  const text = messages.map(m => m.content.toLowerCase()).join(' ');
+  if (/leak|pipe|faucet|sink|toilet/.test(text)) {
+    return 'plumbing';
+  }
+  if (/electrical|outlet|switch|breaker|power/.test(text)) {
+    return 'electrical';
+  }
+  if (/hvac|heater|ac|air conditioner|temperature/.test(text)) {
+    return 'hvac';
+  }
+  if (/fridge|refrigerator|stove|oven|dishwasher|washer|dryer/.test(text)) {
+    return 'appliance';
+  }
+  if (/wall|door|window|floor|ceiling|roof/.test(text)) {
+    return 'structural';
+  }
+  return null;
+}
+
+export function generateFollowUpQuestions(messages: ModelMessage[]): FollowUpQuestion[] {
+  const issue = detectIssueType(messages) || 'other';
+
+  const questionBank: Record<string, FollowUpQuestion[]> = {
+    plumbing: [
+      'Is the leak constant or intermittent?',
+      'Can you shut off the water supply to stop the leak?'
+    ],
+    electrical: [
+      'Does the problem affect multiple outlets or just one?',
+      'Have you noticed any flickering lights or burning smells?'
+    ],
+    hvac: [
+      'Is the system running but not heating or cooling?',
+      'When was the last time the filter was replaced?'
+    ],
+    appliance: [
+      'What is the make and model of the appliance?',
+      'Have you seen any error codes or unusual noises?'
+    ],
+    structural: [
+      'Has this issue been getting worse over time?',
+      'Could you provide a photo of the affected area?'
+    ],
+    other: [
+      'Could you share more details about the issue?',
+      'A photo would help us understand better.'
+    ]
+  };
+
+  const baseQuestions = questionBank[issue] || questionBank.other;
+
+  return baseQuestions;
+}


### PR DESCRIPTION
## Summary
- add follow-up conversation UI `AIMaintenanceChat`
- implement `questionEngine` for follow-up prompts
- extend `useMaintenanceAI` with conversation support

## Testing
- `npx tsc --noEmit` *(fails: cannot find module 'firebase/firestore')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a0861cd08326b0d44aa94f65d7ff